### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start database
+        run: docker compose up -d --wait db
+
+      - name: Build app image
+        run: docker compose build app
+
+      - name: Prepare test database
+        run: docker compose run --rm app bin/rails db:create db:test:prepare
+
+      - name: Run tests
+        run: docker compose run --rm app bin/rails test
+
+      - name: Check Zeitwerk eager loading
+        run: docker compose run --rm app bin/rails zeitwerk:check
+
+      - name: Precompile assets (production)
+        run: docker compose run --rm -e RAILS_ENV=production -e SECRET_KEY_BASE=dummy app bin/rails assets:precompile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     volumes:
       - db-data:/var/lib/mysql
       - ./db/grant.sql:/docker-entrypoint-initdb.d/grant.sql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   app:
     build: .


### PR DESCRIPTION
## Summary

Add a CI workflow that runs everything through docker compose, so CI uses exactly the same environment as local development (Dockerfile is the single source of truth). No CI changes will be needed as the Ruby/Rails upgrade ladder proceeds.

## Workflow

Triggers on pushes to main and on pull requests:

1. `docker compose up -d --wait db` (a healthcheck was added to the db service)
2. `docker compose build app`
3. `bin/rails db:create db:test:prepare`
4. `bin/rails test`
5. `bin/rails zeitwerk:check`
6. `RAILS_ENV=production bin/rails assets:precompile` (smoke test)

## Notes

- The db healthcheck also prevents db:create races on local first runs
- Build caching (buildx gha cache) can be added later if CI time becomes an issue

Generated with [Claude Code](https://claude.com/claude-code)