### PR TITLE
Add system tests for JS-dependent flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
       - name: Run tests
         run: docker compose run --rm app bin/rails test
 
+      - name: Run system tests
+        run: docker compose run --rm app bin/rails test:system
+
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: tmp/screenshots
+          if-no-files-found: ignore
+
       - name: Check Zeitwerk eager loading
         run: docker compose run --rm app bin/rails zeitwerk:check
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /app
 
 # mysql CLI is required to load structure.sql (db:structure:load)
 # nodejs is for uglifier (ExecJS)
+# chromium and chromium-driver are for system tests (headless)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends default-mysql-client nodejs \
+       chromium chromium-driver \
     && rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundler -v 2.3.27

--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,11 @@ group :development do
   gem 'listen', '~> 3.3'
 end
 
+group :test do
+  # System tests run against headless Chromium installed in the Docker image
+  gem 'capybara'
+  gem 'selenium-webdriver'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     autoprefixer-rails (10.2.5.1)
       execjs (> 0)
     base64 (0.3.0)
@@ -73,6 +75,15 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.3.0)
     byebug (11.1.3)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     crass (1.0.7)
@@ -104,6 +115,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
+    matrix (0.4.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
@@ -130,6 +142,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (6.0.2)
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -167,6 +180,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -175,6 +191,12 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.26.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sprockets (3.7.5)
       base64
       concurrent-ruby (~> 1.0)
@@ -198,10 +220,13 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    websocket (1.2.11)
     websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -211,6 +236,7 @@ DEPENDENCIES
   bootsnap (>= 1.16)
   bootstrap (~> 4.3.1)
   byebug
+  capybara
   dovecot_crammd5
   jquery-rails
   listen (~> 3.3)
@@ -219,6 +245,7 @@ DEPENDENCIES
   puma (~> 6.4)
   rails (~> 6.1.7)
   sassc-rails
+  selenium-webdriver
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 900] do |options|
+    options.binary = '/usr/bin/chromium'
+    # Required to run Chromium inside the Docker container
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-gpu')
+    options.add_argument('--disable-dev-shm-usage')
+  end
+
+  def sign_in_as(username, password)
+    visit login_path
+    fill_in "username", with: username
+    fill_in "password", with: password
+    click_button "Sign in"
+  end
+
+  def sign_in_super_ui
+    sign_in_as("admin@example.com", "adminpass")
+  end
+end

--- a/test/system/alias_forward_addresses_test.rb
+++ b/test/system/alias_forward_addresses_test.rb
@@ -1,0 +1,36 @@
+require 'application_system_test_case'
+
+# The alias edit form is the only custom JS in the app
+# (dynamic add/remove of forward address rows)
+class AliasForwardAddressesTest < ApplicationSystemTestCase
+  FORWARD_INPUTS = 'input[name="alias[forward_addresses][]"]'.freeze
+
+  test "add a forward address" do
+    sign_in_super_ui
+    visit edit_domain_alias_path("example.com", "info@example.com")
+
+    # existing goto + one trailing empty row
+    assert_selector FORWARD_INPUTS, count: 2
+
+    click_button "Add"
+    assert_selector FORWARD_INPUTS, count: 3
+
+    all(FORWARD_INPUTS).last.set("added@example.org")
+    click_button "Update Alias"
+
+    assert_text "Alias was successfully updated."
+    assert_equal "external@example.org,added@example.org",
+                 Alias.find("info@example.com").goto
+  end
+
+  test "remove a forward address row" do
+    sign_in_super_ui
+    visit edit_domain_alias_path("example.com", "info@example.com")
+
+    click_button "Add"
+    assert_selector FORWARD_INPUTS, count: 3
+
+    all(".delete-forward-address-button").last.click
+    assert_selector FORWARD_INPUTS, count: 2
+  end
+end

--- a/test/system/logins_test.rb
+++ b/test/system/logins_test.rb
@@ -1,0 +1,13 @@
+require 'application_system_test_case'
+
+class LoginsTest < ApplicationSystemTestCase
+  test "login and see domains" do
+    sign_in_super_ui
+    assert_selector "td", text: "example.com"
+  end
+
+  test "login with wrong password shows alert" do
+    sign_in_as("admin@example.com", "wrongpass")
+    assert_text "Incorrect username or password."
+  end
+end

--- a/test/system/mailbox_deletions_test.rb
+++ b/test/system/mailbox_deletions_test.rb
@@ -1,0 +1,16 @@
+require 'application_system_test_case'
+
+class MailboxDeletionsTest < ApplicationSystemTestCase
+  test "delete a mailbox with confirmation dialog" do
+    sign_in_super_ui
+    visit domain_mailboxes_path("example.com")
+    assert_text "user1@example.com"
+
+    accept_confirm do
+      click_link "Delete"
+    end
+
+    assert_no_text "user1@example.com"
+    assert_not Mailbox.exists?("user1@example.com")
+  end
+end

--- a/test/system/navbar_test.rb
+++ b/test/system/navbar_test.rb
@@ -1,0 +1,15 @@
+require 'application_system_test_case'
+
+class NavbarTest < ApplicationSystemTestCase
+  test "user menu dropdown opens and signs out" do
+    sign_in_super_ui
+
+    # menu items are hidden until the dropdown is opened
+    assert_no_link "Sign out"
+    click_button "admin@example.com"
+    assert_link "Profile"
+
+    click_link "Sign out"
+    assert_text "Please sign in"
+  end
+end


### PR DESCRIPTION
## Summary

The upcoming Hotwire (turbolinks -> Turbo, rails-ujs removal) and Tailwind (custom dropdown JS, aliases.js selector changes) migrations mostly change JS behavior, which the existing integration tests cannot exercise. This PR automates the flows that were previously verified manually in the browser, so those phases get CI-verified regression coverage.

## Tests (6 runs, test/system/)

- Login success and failure
- Alias forward address form - the only custom JS in the app: adding a row, saving the joined goto, removing a row
- Navbar dropdown open and sign out
- Mailbox deletion through the confirm dialog (accept_confirm)

## Setup

- Dockerfile: install `chromium` + `chromium-driver` (version-matched Debian packages, works on arm64 local and amd64 CI)
- Gemfile test group: capybara 3.40, selenium-webdriver 4.26 (Selenium Manager picks up the chromedriver from PATH)
- `bin/rails test` stays fast - system tests only run via `test:system`
- CI: add a test:system step and upload failure screenshots (tmp/screenshots) as an artifact

## Verification

- Local (arm64): 6 runs green in about 2.5s
- Detection check: deliberately breaking the aliases.js selector makes the two form tests fail; restoring makes them green again
- CI (amd64): this PR's checks verify it

Generated with [Claude Code](https://claude.com/claude-code)