### PR TITLE
Migrate from Bootstrap to Tailwind CSS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Prepare test database
         run: docker compose run --rm app bin/rails db:create db:test:prepare
 
+      - name: Build Tailwind CSS
+        run: docker compose run --rm app bin/rails tailwindcss:build
+
       - name: Run tests
         run: docker compose run --rm app bin/rails test
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 /config/credentials.yml.enc
 
 /.idea/*
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,9 @@ FROM ruby:3.0.7
 WORKDIR /app
 
 # mysql CLI is required to load structure.sql (db:structure:load)
-# nodejs is for autoprefixer-rails via the bootstrap gem (ExecJS,
-# goes away with the Tailwind migration)
 # chromium and chromium-driver are for system tests (headless)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends default-mysql-client nodejs \
+    && apt-get install -y --no-install-recommends default-mysql-client \
        chromium chromium-driver \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,10 @@ gem 'rails', '~> 6.1.7'
 gem 'mysql2', '~> 0.5', '>= 0.5.4'
 # Use Puma as the app server
 gem 'puma', '~> 6.4'
-# Use SCSS for stylesheets
-gem 'sassc-rails'
 # Sprockets 4 reads app/assets/config/manifest.js (required for importmap assets)
 gem 'sprockets', '~> 4.0'
+# Tailwind CSS via the standalone binary (no Node required)
+gem 'tailwindcss-rails', '~> 2.0'
 # Hotwire: import maps for JavaScript and Turbo for page navigation
 # (importmap-rails 2.x requires Ruby 3.1+, so 1.x is pinned for now.
 #  turbo-rails must be 2.x: Turbo 7 misjudges this app's URLs, whose
@@ -23,9 +23,6 @@ gem 'turbo-rails', '~> 2.0'
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
-gem 'bootstrap', '~> 4.3.1'
-gem 'jquery-rails'
 
 gem 'dovecot_crammd5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,17 +62,11 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    autoprefixer-rails (10.2.5.1)
-      execjs (> 0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    bootstrap (4.3.1)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 1.14.3, < 2)
-      sassc-rails (>= 2.0.0)
     builder (3.3.0)
     byebug (11.1.3)
     capybara (3.40.0)
@@ -90,7 +84,6 @@ GEM
     date (3.5.1)
     dovecot_crammd5 (0.0.3)
     erubi (1.13.1)
-    execjs (2.8.1)
     ffi (1.17.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -100,10 +93,6 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    jquery-rails (4.4.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     listen (3.10.0)
       logger
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -140,7 +129,10 @@ GEM
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    popper_js (1.16.0)
+    nokogiri (1.13.10-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -187,14 +179,6 @@ GEM
     regexp_parser (2.12.0)
     rexml (3.4.4)
     rubyzip (2.4.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (4.26.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -209,8 +193,13 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    tailwindcss-rails (2.5.0)
+      railties (>= 6.0.0)
+    tailwindcss-rails (2.5.0-aarch64-linux)
+      railties (>= 6.0.0)
+    tailwindcss-rails (2.5.0-x86_64-linux)
+      railties (>= 6.0.0)
     thor (1.5.0)
-    tilt (2.0.10)
     timeout (0.6.1)
     turbo-rails (2.0.12)
       actionpack (>= 6.0.0)
@@ -232,24 +221,24 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  aarch64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.16)
-  bootstrap (~> 4.3.1)
   byebug
   capybara
   dovecot_crammd5
   importmap-rails (~> 1.2)
-  jquery-rails
   listen (~> 3.3)
   mysql2 (~> 0.5, >= 0.5.4)
   pry-rails
   puma (~> 6.4)
   rails (~> 6.1.7)
-  sassc-rails
   selenium-webdriver
   sprockets (~> 4.0)
+  tailwindcss-rails (~> 2.0)
   turbo-rails (~> 2.0)
   tzinfo-data
   web-console (~> 4.0)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ docker compose up app   # http://localhost:3000 (admin@example.com / adminpass)
 
 The schema is managed with `db/structure.sql`, not with migrations.
 
+Stylesheets are built with Tailwind CSS. Rebuild after changing views or
+`app/assets/stylesheets/application.tailwind.css`:
+
+```
+docker compose run --rm app bin/rails tailwindcss:build
+```
+
 ## Production
 
 `secret_key_base` is required in production. This repository does not ship

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link_tree ../images
-//= link legacy.js
-//= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/app/assets/javascripts/legacy.js
+++ b/app/assets/javascripts/legacy.js
@@ -1,5 +1,0 @@
-// jQuery and Bootstrap 4 JS kept only for the navbar dropdown
-// (to be removed in the Tailwind migration)
-//= require jquery3
-//= require popper
-//= require bootstrap-sprockets

--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the admins controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/aliases.scss
+++ b/app/assets/stylesheets/aliases.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the aliases controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,0 @@
-// Custom bootstrap variables must be set or imported *before* bootstrap.
-@import "bootstrap";
-
-div.card-form {
-  width: 50%;
-  div.number {
-    width: 30%;
-  }
-}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,71 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .btn {
+    @apply inline-block rounded px-3 py-1.5 text-sm font-medium cursor-pointer;
+  }
+  .btn-primary {
+    @apply bg-blue-600 text-white hover:bg-blue-700;
+  }
+  .btn-secondary {
+    @apply bg-gray-500 text-white hover:bg-gray-600;
+  }
+  .btn-danger {
+    @apply bg-red-600 text-white hover:bg-red-700;
+  }
+  .btn-info {
+    @apply bg-sky-600 text-white hover:bg-sky-700;
+  }
+  .btn-new {
+    @apply border border-green-600 text-green-700 hover:bg-green-50;
+  }
+  .btn-sm {
+    @apply px-2 py-1 text-xs;
+  }
+
+  .form-label {
+    @apply block text-sm font-medium text-gray-700 mb-1;
+  }
+  .form-input {
+    @apply w-full rounded border border-gray-300 px-3 py-1.5 text-sm
+           focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500;
+  }
+  .form-checkbox {
+    @apply rounded border-gray-300 text-blue-600 focus:ring-blue-500;
+  }
+
+  .card {
+    @apply max-w-xl rounded border border-gray-200 bg-white shadow-sm;
+  }
+  .card-header {
+    @apply border-b border-gray-200 bg-gray-50 px-4 py-3 text-lg font-semibold rounded-t;
+  }
+  .card-body {
+    @apply px-4 py-4 space-y-4;
+  }
+  .card-footer {
+    @apply border-t border-gray-200 bg-gray-50 px-4 py-3 flex gap-2 rounded-b;
+  }
+
+  .table-admin {
+    @apply w-full border-collapse bg-white text-sm shadow-sm;
+  }
+  .table-admin th {
+    @apply bg-gray-800 px-3 py-2 text-white font-medium;
+  }
+  .table-admin td {
+    @apply border-b border-gray-200 px-3 py-2;
+  }
+  .row-inactive {
+    @apply bg-gray-100 text-gray-500;
+  }
+
+  .alert-notice {
+    @apply mb-4 rounded border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800;
+  }
+  .alert-error {
+    @apply mb-4 rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800;
+  }
+}

--- a/app/assets/stylesheets/domains.scss
+++ b/app/assets/stylesheets/domains.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the domains controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/mailboxes.scss
+++ b/app/assets/stylesheets/mailboxes.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the mailboxes controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the profile controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the sessions controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/javascript/aliases.js
+++ b/app/javascript/aliases.js
@@ -1,6 +1,6 @@
 (function() {
     function deleteAddress() {
-        this.parentNode.parentNode.remove();
+        this.parentNode.remove();
     }
 
     document.addEventListener("turbo:load", function () {
@@ -16,8 +16,8 @@
             input.removeAttribute("readonly");
             var button = newAddress.querySelector(".delete-forward-address-button");
             button.removeAttribute("disabled");
+            button.classList.remove("hidden");
             button.addEventListener('click', deleteAddress);
-            newAddress.querySelector(".input-group-append").classList.remove("d-none");
             addButton.parentNode.insertBefore(newAddress, addButton);
         });
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "aliases"
+import "dropdown"

--- a/app/javascript/dropdown.js
+++ b/app/javascript/dropdown.js
@@ -1,0 +1,14 @@
+// User menu dropdown in the navbar
+// A single delegated listener keeps working across Turbo page visits
+document.addEventListener("click", function (event) {
+    var toggle = document.getElementById("user-menu-button");
+    var menu = document.getElementById("user-menu");
+    if (toggle === null || menu === null) {
+        return;
+    }
+    if (toggle.contains(event.target)) {
+        menu.classList.toggle("hidden");
+    } else if (!menu.contains(event.target)) {
+        menu.classList.add("hidden");
+    }
+});

--- a/app/views/admins/_form.html.erb
+++ b/app/views/admins/_form.html.erb
@@ -1,14 +1,14 @@
 <% if flash[:notice] %>
-  <div class="alert alert-primary" role="alert"><%= notice %></div>
+  <div class="alert-notice" role="alert"><%= notice %></div>
 <% end %>
 
 <%= form_for(@admin) do |f| %>
   <div class="card-body">
   <% if @admin.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@admin.errors.count, "error") %> prohibited this admin from being saved:</h2>
+    <div id="error_explanation" class="alert-error">
+      <h2 class="font-semibold"><%= pluralize(@admin.errors.count, "error") %> prohibited this admin from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% @admin.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
@@ -16,55 +16,50 @@
     </div>
   <% end %>
 
-  <div class="form-group">
-    <%= f.label :username %><br>
+  <div>
+    <%= f.label :username, class: "form-label" %>
     <% if controller.action_name == "edit" %>
-      <%= f.hidden_field :username, size: 50 %>
+      <%= f.hidden_field :username %>
       <%= @admin.username %>
     <% else %>
-      <%= f.text_field :username, size: 50, class: "form-control" %>
+      <%= f.text_field :username, class: "form-input" %>
     <% end %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :password_unencrypted %><br>
-    <%= f.password_field :password_unencrypted,
-                         size: 50, class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :password_unencrypted_confirmation %><br>
-    <%= f.password_field :password_unencrypted_confirmation,
-                         size: 50, class: "form-control" %>
-  </div>
-
-  <div class="form-group form-check">
-    <%= f.check_box :active, class: "form-check-input" %>
-    <%= f.label :active, class: "form-check-label" %>
-  </div>
-
-  <div class="form-group form-check">
-    <%= f.check_box :form_super_admin, class: "form-check-input" %>
-    <%= f.label :form_super_admin, class: "form-check-label" %>
+  <div>
+    <%= f.label :password_unencrypted, class: "form-label" %>
+    <%= f.password_field :password_unencrypted, class: "form-input" %>
   </div>
 
   <div>
-    <%= f.label :domain_ids %>
-    <div  class="form-group form-check">
-      <ul>
-        <%= f.collection_check_boxes(:domain_ids, @domains, :domain,
-                                     :domain) do |b| %>
-          <li><%= b.label(class: "form-check-label") { b.check_box(class: "form-check-input") + b.text } %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= f.label :password_unencrypted_confirmation, class: "form-label" %>
+    <%= f.password_field :password_unencrypted_confirmation, class: "form-input" %>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= f.check_box :active, class: "form-checkbox" %>
+    <%= f.label :active, class: "text-sm text-gray-700" %>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= f.check_box :form_super_admin, class: "form-checkbox" %>
+    <%= f.label :form_super_admin, class: "text-sm text-gray-700" %>
+  </div>
+
+  <div>
+    <%= f.label :domain_ids, class: "form-label" %>
+    <ul class="space-y-1">
+      <%= f.collection_check_boxes(:domain_ids, @domains, :domain,
+                                   :domain) do |b| %>
+        <li><%= b.label(class: "flex items-center gap-2 text-sm text-gray-700") { b.check_box(class: "form-checkbox") + b.text } %></li>
+      <% end %>
+    </ul>
   </div>
 </div>
 
   <div class="card-footer">
     <%= f.submit(class: "btn btn-primary") %>
-    <%= link_to "Cancel", admins_path, role: "button",
-                class: "btn btn-secondary" %>
+    <%= link_to "Cancel", admins_path, class: "btn btn-secondary" %>
   </div>
 
 <% end %>

--- a/app/views/admins/edit.html.erb
+++ b/app/views/admins/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">Edit admin</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,12 +1,12 @@
 <% if flash[:notice] %>
-  <div class="alert alert-primary" role="alert"><%= notice %></div>
+  <div class="alert-notice" role="alert"><%= notice %></div>
 <% end %>
 
-<table class="table">
-  <thead class="thead-dark">
+<table class="table-admin">
+  <thead>
   <tr>
     <th class="text-center">#</th>
-    <th>Admin</th>
+    <th class="text-left">Admin</th>
     <th class="text-center">Domains</th>
     <th class="text-center">Status</th>
     <th class="text-center">Edit</th>
@@ -18,8 +18,7 @@
   </thead>
   <tbody>
   <% @admins.each_with_index do |admin, i| %>
-    <% tr_class = admin.active? ? "" : "table-secondary" %>
-    <tr class="<%= tr_class %>">
+    <tr class="<%= admin.active? ? "" : "row-inactive" %>">
       <td class="text-center"><%= i+1 %></td>
       <td><%= admin.username %></td>
       <td class="text-center">
@@ -31,17 +30,16 @@
       </td>
       <td class="text-center"><%= admin.active_str %></td>
       <td class="text-center"><%= link_to "Edit", edit_admin_path(admin),
-                      role: "button", class: "btn btn-info btn-sm"%></td>
+                      class: "btn btn-sm btn-info" %></td>
       <% if @current_admin.super_admin? %>
         <td class="text-center">
           <% if @current_admin == admin %>
-            <%= link_to "Delete", "", role: "button",
-                        class: "btn btn-secondary btn-sm disabled",
-                        "aria-disabled": "true" %>
+            <span class="btn btn-sm bg-gray-200 text-gray-400 cursor-not-allowed"
+                  aria-disabled="true">Delete</span>
           <% else %>
             <%= button_to "Delete", admin, method: :delete,
                           form: { data: { turbo_confirm: 'Are you sure?' } },
-                          class: "btn btn-secondary btn-sm" %>
+                          class: "btn btn-sm btn-danger" %>
           <% end %>
         </td>
       <% end %>

--- a/app/views/admins/new.html.erb
+++ b/app/views/admins/new.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">New admin</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/aliases/_form.html.erb
+++ b/app/views/aliases/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_for([@domain, @alias]) do |f| %>
   <div class="card-body">
   <% if @alias.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@alias.errors.count, "error") %> prohibited this alias from being saved:</h2>
+    <div id="error_explanation" class="alert-error">
+      <h2 class="font-semibold"><%= pluralize(@alias.errors.count, "error") %> prohibited this alias from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% @alias.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
@@ -12,40 +12,37 @@
     </div>
   <% end %>
 
-  <div class="form-group">
-    <%= f.label :local_part %><br>
+  <div>
+    <%= f.label :local_part, class: "form-label" %>
     <% if controller.action_name == "edit" %>
-      <%= f.hidden_field :local_part, size: 20 %>
+      <%= f.hidden_field :local_part %>
       <%= @alias.address %>
     <% else %>
-      <div class="input-group">
-        <%= f.text_field :local_part, size: 20, class: "form-control" %>
-        <div class="input-group-append">
-          <div class="input-group-text">@<%= @domain.domain %></div>
-        </div>
+      <div class="flex">
+        <%= f.text_field :local_part, class: "form-input rounded-r-none" %>
+        <span class="inline-flex items-center rounded-r border border-l-0 border-gray-300 bg-gray-100 px-3 text-sm text-gray-600">@<%= @domain.domain %></span>
       </div>
     <% end %>
 
   </div>
 
-  <div class="form-group" id="forward-address-group">
-    <%= f.label :goto %>
+  <div id="forward-address-group">
+    <%= f.label :goto, class: "form-label" %>
     <% @alias.forward_addresses.each_with_index do |f, i| %>
-      <div class="input-group mb-2 forward-address">
-      <%= text_field_tag 'alias[forward_addresses][]', f, size: 50,
-                         class: "form-control", readonly: i == 0 && @alias.mailbox? %>
-        <div class="input-group-append <%= i == 0 ? "d-none" : "" %>">
-          <button class="btn btn-outline-info delete-forward-address-button" type="button" <%= i == 0 ? "disabled" : "" %>>Delete</button>
-        </div>
+      <div class="forward-address mb-2 flex gap-2">
+      <%= text_field_tag 'alias[forward_addresses][]', f,
+                         class: "form-input",
+                         readonly: i == 0 && @alias.mailbox? %>
+        <button class="delete-forward-address-button btn btn-danger <%= i == 0 ? "hidden" : "" %>" type="button" <%= i == 0 ? "disabled" : "" %>>Delete</button>
       </div>
     <% end %>
-    <button class="btn btn-outline-info" id="add-forward-address-button" type="button">Add</button>
+    <button class="btn btn-new" id="add-forward-address-button" type="button">Add</button>
   </div>
 
   <% if @alias.pure_alias? %>
-  <div class="form-group form-check">
-    <%= f.check_box :active, class: "form-check-input" %>
-    <%= f.label :active, class: "form-check-label" %>
+  <div class="flex items-center gap-2">
+    <%= f.check_box :active, class: "form-checkbox" %>
+    <%= f.label :active, class: "text-sm text-gray-700" %>
   </div>
   <% end %>
   </div>
@@ -54,8 +51,7 @@
 
   <div class="card-footer">
     <%= f.submit(class: "btn btn-primary") %>
-    <%= link_to "Cancel", cancel_path, role: "button",
-                class: "btn btn-secondary" %>
+    <%= link_to "Cancel", cancel_path, class: "btn btn-secondary" %>
   </div>
 
 <% end %>

--- a/app/views/aliases/edit.html.erb
+++ b/app/views/aliases/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">Edit alias</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/aliases/index.html.erb
+++ b/app/views/aliases/index.html.erb
@@ -1,11 +1,11 @@
 <%= render "domains/info" %>
 
-<table class="table">
-  <thead class="thead-dark">
+<table class="table-admin">
+  <thead>
   <tr>
     <th class="text-center">#</th>
-    <th>Alias</th>
-    <th>To</th>
+    <th class="text-left">Alias</th>
+    <th class="text-left">To</th>
     <th class="text-center">Status</th>
     <th class="text-center">Edit</th>
     <th class="text-center">Delete</th>
@@ -14,9 +14,8 @@
   </thead>
   <tbody>
   <% @domain.pure_aliases.each_with_index do |a, i| %>
-    <% tr_class = a.active? ? "" : "table-secondary" %>
-    <tr class="<%= tr_class %>">
-      <td><%= i+1 %></td>
+    <tr class="<%= a.active? ? "" : "row-inactive" %>">
+      <td class="text-center"><%= i+1 %></td>
       <td><%= a.address %></td>
       <td>
         <% a.gotos.each do |g| %>
@@ -25,10 +24,10 @@
       </td>
       <td class="text-center"><%= a.active_str %></td>
       <td class="text-center"><%= link_to "Edit", edit_domain_alias_path(@domain, a),
-                      role: "button", class: "btn btn-info btn-sm" %></td>
+                      class: "btn btn-sm btn-info" %></td>
       <td class="text-center"><%= button_to "Delete", domain_alias_path(@domain, a), method: :delete,
                       form: { data: { turbo_confirm: 'Are you sure?' } },
-                      class: "btn btn-secondary btn-sm" %></td>
+                      class: "btn btn-sm btn-danger" %></td>
       <td class="text-center"><%= l a.modified %></td>
     </tr>
   <% end %>

--- a/app/views/aliases/new.html.erb
+++ b/app/views/aliases/new.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">New alias</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/domains/_form.html.erb
+++ b/app/views/domains/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_for(@domain) do |f| %>
   <div class="card-body">
   <% if @domain.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@domain.errors.count, "error") %> prohibited this domain from being saved:</h2>
+    <div id="error_explanation" class="alert-error">
+      <h2 class="font-semibold"><%= pluralize(@domain.errors.count, "error") %> prohibited this domain from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% @domain.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
@@ -12,46 +12,45 @@
     </div>
   <% end %>
 
-  <div class="form-group">
-    <%= f.label :domain %><br>
+  <div>
+    <%= f.label :domain, class: "form-label" %>
     <% if controller.action_name == "edit" %>
-      <%= f.hidden_field :domain, size: 50 %>
+      <%= f.hidden_field :domain %>
       <%= @domain.domain %>
     <% else %>
-      <%= f.text_field :domain, size: 50, class: "form-control" %>
+      <%= f.text_field :domain, class: "form-input" %>
     <% end %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :description %><br>
-    <%= f.text_field :description, size: 50, class: "form-control" %>
+  <div>
+    <%= f.label :description, class: "form-label" %>
+    <%= f.text_field :description, class: "form-input" %>
   </div>
 
-  <div class="form-group number">
-    <%= f.label :aliases %><br>
-    <%= f.text_field :aliases, size: 50, class: "form-control" %>
+  <div>
+    <%= f.label :aliases, class: "form-label" %>
+    <%= f.text_field :aliases, class: "form-input w-40" %>
   </div>
 
-  <div class="form-group number">
-    <%= f.label :mailboxes %><br>
-    <%= f.text_field :mailboxes, size: 50, class: "form-control" %>
+  <div>
+    <%= f.label :mailboxes, class: "form-label" %>
+    <%= f.text_field :mailboxes, class: "form-input w-40" %>
   </div>
 
-  <div class="form-group number">
-    <%= f.label :maxquota %><br>
-    <%= f.text_field :maxquota, size: 50, class: "form-control" %>
+  <div>
+    <%= f.label :maxquota, class: "form-label" %>
+    <%= f.text_field :maxquota, class: "form-input w-40" %>
   </div>
 
-  <div class="form-group form-check">
-    <%= f.check_box :active, class: "form-check-input" %>
-    <%= f.label :active, class: "form-check-label" %>
+  <div class="flex items-center gap-2">
+    <%= f.check_box :active, class: "form-checkbox" %>
+    <%= f.label :active, class: "text-sm text-gray-700" %>
   </div>
   </div>
 
   <div class="card-footer">
     <%= f.submit(class: "btn btn-primary") %>
-    <%= link_to "Cancel", domains_path, role: "button",
-                          class: "btn btn-secondary" %>
+    <%= link_to "Cancel", domains_path, class: "btn btn-secondary" %>
   </div>
 
 <% end %>

--- a/app/views/domains/_info.html.erb
+++ b/app/views/domains/_info.html.erb
@@ -1,36 +1,34 @@
-<h1><%= @domain.domain %></h1>
+<h1 class="mb-4 text-2xl font-bold text-gray-900"><%= @domain.domain %></h1>
 
-<div class="mb-3 clearfix">
-  <ul class="list-group list-group-horizontal float-left">
-    <li class="list-group-item">
+<div class="mb-4 flex flex-wrap items-center gap-4">
+  <div class="flex rounded border border-gray-200 bg-white text-sm shadow-sm divide-x divide-gray-200">
+    <div class="px-4 py-2">
       <%= link_to "Mailboxes", domain_mailboxes_path(@domain),
-                  style: "text-decoration: underline" %>
+                  class: "underline text-blue-700" %>
       <%= @domain.rel_mailboxes.count %> / <%= @domain.mailboxes_str %>
-    </li>
-    <li class="list-group-item">
+    </div>
+    <div class="px-4 py-2">
       <%= link_to "Aliases", domain_aliases_path(@domain),
-                  style: "text-decoration: underline" %>
+                  class: "underline text-blue-700" %>
       <%= @domain.pure_aliases.count %> / <%= @domain.aliases_str %>
-    </li>
-    <li class="list-group-item">
-      <span class="font-weight-bold">Max Quota</span>
+    </div>
+    <div class="px-4 py-2">
+      <span class="font-semibold">Max Quota</span>
       <%= @domain.maxquota_str %>
-    </li>
-    <% active_class = @domain.active? ? "list-group-item-success" : "list-group-item-secondary" %>
-    <li class="list-group-item <%= active_class %>">
-      <span class="font-weight-bold">Status</span>
+    </div>
+    <% active_class = @domain.active? ? "bg-green-50 text-green-800" : "bg-gray-100 text-gray-500" %>
+    <div class="px-4 py-2 <%= active_class %>">
+      <span class="font-semibold">Status</span>
       <%= @domain.active_str %>
-    </li>
-  </ul>
+    </div>
+  </div>
 
-  <div class=" float-left pt-1 ml-3">
-    <%= link_to "New mailbox", new_domain_mailbox_path(@domain),
-                role: "button", class: "btn btn-outline-success mx-2" %>
-    <%= link_to "New alias", new_domain_alias_path(@domain),
-                role: "button", class: "btn btn-outline-success mx-2" %>
+  <div class="flex gap-2">
+    <%= link_to "New mailbox", new_domain_mailbox_path(@domain), class: "btn btn-new" %>
+    <%= link_to "New alias", new_domain_alias_path(@domain), class: "btn btn-new" %>
   </div>
 </div>
 
 <% if flash[:notice] %>
-  <div class="alert alert-primary" role="alert"><%= notice %></div>
+  <div class="alert-notice" role="alert"><%= notice %></div>
 <% end %>

--- a/app/views/domains/edit.html.erb
+++ b/app/views/domains/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">Edit domain</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -1,13 +1,13 @@
 <% if flash[:notice] %>
-  <div class="alert alert-primary" role="alert"><%= notice %></div>
+  <div class="alert-notice" role="alert"><%= notice %></div>
 <% end %>
 
-<table class="table">
-  <thead class="thead-dark">
+<table class="table-admin">
+  <thead>
   <tr>
     <th class="text-center">#</th>
-    <th>Domain</th>
-    <th>Description</th>
+    <th class="text-left">Domain</th>
+    <th class="text-left">Description</th>
     <th class="text-center">Mailboxes</th>
     <th class="text-center">Aliases</th>
     <th class="text-center">Max Quota</th>
@@ -22,8 +22,7 @@
   </thead>
   <tbody>
   <% @domains.each_with_index do |domain, i| %>
-    <% tr_class = domain.active? ? "" : "table-secondary" %>
-    <tr class="<%= tr_class %>">
+    <tr class="<%= domain.active? ? "" : "row-inactive" %>">
       <td class="text-center"><%= i+1 %></td>
       <td><%= domain.domain %></td>
       <td><%= domain.description %></td>
@@ -43,15 +42,13 @@
       </td>
       <td class="text-center"><%= domain.maxquota_short_str %></td>
       <td class="text-center"><%= domain.active_str %></td>
-      <td><%= link_to "Show", domain,
-                      role: "button", class: "btn btn-primary btn-sm" %></td>
+      <td class="text-center"><%= link_to "Show", domain, class: "btn btn-sm btn-primary" %></td>
 
       <% if @current_admin.super_admin? %>
-        <td><%= link_to "Edit", edit_domain_path(domain),
-                        role: "button", class: "btn btn-info btn-sm" %></td>
-        <td><%= button_to "Delete", domain, method: :delete,
-                          form: { data: { turbo_confirm: 'Are you sure?' } },
-                          class: "btn btn-secondary btn-sm" %></td>
+        <td class="text-center"><%= link_to "Edit", edit_domain_path(domain), class: "btn btn-sm btn-info" %></td>
+        <td class="text-center"><%= button_to "Delete", domain, method: :delete,
+                        form: { data: { turbo_confirm: 'Are you sure?' } },
+                        class: "btn btn-sm btn-danger" %></td>
       <% end %>
       <td class="text-center"><%= l domain.modified %></td>
     </tr>

--- a/app/views/domains/new.html.erb
+++ b/app/views/domains/new.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">New domain</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,56 +4,52 @@
     <title>MailAdmin</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track': 'reload' %>
-    <%= javascript_include_tag 'legacy', 'data-turbo-track': 'reload' %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-  <div class="container" style="margin-bottom: 30px">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light" style="margin-bottom: 20px">
-      <%= link_to "MailAdmin", root_path, class: "navbar-brand" %>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav">
-          <% admins_class = controller.controller_name == "admins" ? "active" : ""  %>
-          <% domains_class = controller.controller_name == "domains" ? "active" : ""  %>
+  <body class="bg-gray-100 min-h-screen">
+    <nav class="bg-white border-b border-gray-200 shadow-sm">
+      <div class="mx-auto max-w-6xl px-4 py-3 flex items-center gap-6">
+        <%= link_to "MailAdmin", root_path,
+                    class: "navbar-brand text-lg font-bold text-gray-900" %>
+
+        <div class="flex items-center gap-4 text-sm">
           <% if @current_admin.super_admin? %>
-          <li class="nav-item <%= admins_class %>">
-            <%= link_to "Admins", admins_path, class: "nav-link",
-                        style: "text-decoration: underline" %>
-          </li>
+            <% admins_class = controller.controller_name == "admins" ? "text-blue-700 font-semibold" : "text-gray-600" %>
+            <%= link_to "Admins", admins_path,
+                        class: "#{admins_class} underline hover:text-blue-700" %>
           <% end %>
-          <li class="nav-item <%= domains_class %>">
-            <%= link_to "Domains", domains_path, class: "nav-link",
-                        style: "text-decoration: underline" %>
-          </li>
-        </ul>
+          <% domains_class = controller.controller_name == "domains" ? "text-blue-700 font-semibold" : "text-gray-600" %>
+          <%= link_to "Domains", domains_path,
+                      class: "#{domains_class} underline hover:text-blue-700" %>
+        </div>
 
         <% if @current_admin.super_admin? %>
-          <%= link_to "New admin", new_admin_path,
-                      role: "button", class: "btn btn-outline-success",
-                      style: "margin: 0 8px" %>
-
-          <%= link_to "New domain", new_domain_path,
-                      role: "button", class: "btn btn-outline-success",
-                      style: "margin: 0 8px" %>
+          <div class="flex items-center gap-2">
+            <%= link_to "New admin", new_admin_path, class: "btn btn-sm btn-new" %>
+            <%= link_to "New domain", new_domain_path, class: "btn btn-sm btn-new" %>
+          </div>
         <% end %>
 
-        <div class="dropdown ml-md-auto">
-          <button class="btn btn-outline-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class=""><%= @current_admin.username %></span>
+        <div class="relative ml-auto">
+          <button type="button" id="user-menu-button"
+                  class="btn border border-blue-600 text-blue-700 hover:bg-blue-50">
+            <%= @current_admin.username %> &#x25BE;
           </button>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-            <%= link_to "Profile", profile_path, class: "dropdown-item" %>
+          <div id="user-menu"
+               class="hidden absolute right-0 mt-1 w-44 rounded border border-gray-200 bg-white py-1 shadow-lg z-10">
+            <%= link_to "Profile", profile_path,
+                        class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
             <%= button_to "Sign out", logout_path, method: :delete,
-                          class: "dropdown-item" %>
+                          class: "block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100" %>
           </div>
         </div>
       </div>
     </nav>
 
-    <%= yield %>
-  </div>
+    <main class="mx-auto max-w-6xl px-4 py-6">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/layouts/signin.html.erb
+++ b/app/views/layouts/signin.html.erb
@@ -4,15 +4,14 @@
     <title>Mailadmin</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track': 'reload' %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body style="text-align: center;">
-  <div class="container">
-    <h1 style="margin-top: 50px">Mailadmin</h1>
-    <%= yield %>
-  </div>
+  <body class="bg-gray-100 min-h-screen text-center">
+    <div class="mx-auto max-w-6xl px-4">
+      <h1 class="mt-12 mb-6 text-3xl font-bold text-gray-900">Mailadmin</h1>
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/mailboxes/_form.html.erb
+++ b/app/views/mailboxes/_form.html.erb
@@ -1,15 +1,15 @@
 <% if flash[:notice] %>
-  <div class="alert alert-primary" role="alert"><%= notice %></div>
+  <div class="alert-notice" role="alert"><%= notice %></div>
 <% end %>
 
 
 <%= form_for([@domain, @mailbox]) do |f| %>
   <div class="card-body">
   <% if @mailbox.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@mailbox.errors.count, "error") %> prohibited this mailbox from being saved:</h2>
+    <div id="error_explanation" class="alert-error">
+      <h2 class="font-semibold"><%= pluralize(@mailbox.errors.count, "error") %> prohibited this mailbox from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% @mailbox.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
@@ -17,53 +17,48 @@
     </div>
   <% end %>
 
-  <div class="form-group">
-    <%= f.label :local_part %><br>
+  <div>
+    <%= f.label :local_part, class: "form-label" %>
     <% if controller.action_name == "edit" %>
-      <%= f.hidden_field :local_part, size: 20 %>
+      <%= f.hidden_field :local_part %>
       <%= @mailbox.username %>
     <% else %>
-      <div class="input-group">
-        <%= f.text_field :local_part, size: 20, class: "form-control" %>
-        <div class="input-group-append">
-          <div class="input-group-text">@<%= @domain.domain %></div>
-        </div>
+      <div class="flex">
+        <%= f.text_field :local_part, class: "form-input rounded-r-none" %>
+        <span class="inline-flex items-center rounded-r border border-l-0 border-gray-300 bg-gray-100 px-3 text-sm text-gray-600">@<%= @domain.domain %></span>
       </div>
     <% end %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :name %><br>
-    <%= f.text_field :name, size: 50, class: "form-control" %>
+  <div>
+    <%= f.label :name, class: "form-label" %>
+    <%= f.text_field :name, class: "form-input" %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :password_unencrypted %><br>
-    <%= f.password_field :password_unencrypted, size: 50,
-                         class: "form-control" %>
+  <div>
+    <%= f.label :password_unencrypted, class: "form-label" %>
+    <%= f.password_field :password_unencrypted, class: "form-input" %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :password_unencrypted_confirmation %><br>
-    <%= f.password_field :password_unencrypted_confirmation, size: 50,
-                         class: "form-control" %>
+  <div>
+    <%= f.label :password_unencrypted_confirmation, class: "form-label" %>
+    <%= f.password_field :password_unencrypted_confirmation, class: "form-input" %>
   </div>
 
-  <div class="form-group number">
-    <%= f.label :quota_mb %><br>
-    <%= f.text_field :quota_mb, size: 50, class: "form-control" %>
+  <div>
+    <%= f.label :quota_mb, class: "form-label" %>
+    <%= f.text_field :quota_mb, class: "form-input w-40" %>
   </div>
 
-  <div class="form-group form-check">
-    <%= f.check_box :active, class: "form-check-input" %>
-    <%= f.label :active, class: "form-check-label" %>
+  <div class="flex items-center gap-2">
+    <%= f.check_box :active, class: "form-checkbox" %>
+    <%= f.label :active, class: "text-sm text-gray-700" %>
   </div>
   </div>
 
   <div class="card-footer">
     <%= f.submit(class: "btn btn-primary") %>
-    <%= link_to "Cancel", domain_mailboxes_path(@domain), role: "button",
-                          class: "btn btn-secondary" %>
+    <%= link_to "Cancel", domain_mailboxes_path(@domain), class: "btn btn-secondary" %>
   </div>
 
 <% end %>

--- a/app/views/mailboxes/edit.html.erb
+++ b/app/views/mailboxes/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">Edit mailbox</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/mailboxes/index.html.erb
+++ b/app/views/mailboxes/index.html.erb
@@ -1,12 +1,12 @@
 <%= render "domains/info" %>
 
-<table class="table">
-  <thead class="thead-dark">
+<table class="table-admin">
+  <thead>
   <tr>
     <th class="text-center">#</th>
-    <th>Mailbox</th>
-    <th>To</th>
-    <th>Name</th>
+    <th class="text-left">Mailbox</th>
+    <th class="text-left">To</th>
+    <th class="text-left">Name</th>
     <th class="text-center">Quota</th>
     <th class="text-center">Status</th>
     <th class="text-center">Alias</th>
@@ -17,8 +17,7 @@
   </thead>
   <tbody>
   <% @domain.rel_mailboxes.includes(:alias).each_with_index do |m, i| %>
-    <% tr_class = m.active? ? "" : "table-secondary" %>
-    <tr class="<%= tr_class %>">
+    <tr class="<%= m.active? ? "" : "row-inactive" %>">
       <td class="text-center"><%= i+1 %></td>
       <td><%= m.username %></td>
       <td>
@@ -30,12 +29,12 @@
       <td class="text-center"><%= m.quota_usage_str %>/<%= m.quota_str %></td>
       <td class="text-center"><%= m.active_str %></td>
       <td class="text-center"><%= link_to "alias", edit_domain_alias_path(@domain, m.alias),
-                      role: "button", class: "btn btn-info btn-sm" %></td>
+                      class: "btn btn-sm btn-info" %></td>
       <td class="text-center"><%= link_to "Edit", edit_domain_mailbox_path(@domain, m),
-                      role: "button", class: "btn btn-info btn-sm" %></td>
+                      class: "btn btn-sm btn-info" %></td>
       <td class="text-center"><%= button_to "Delete", domain_mailbox_path(@domain, m), method: :delete,
                       form: { data: { turbo_confirm: 'Are you sure?' } },
-                      class: "btn btn-secondary btn-sm" %></td>
+                      class: "btn btn-sm btn-danger" %></td>
       <td class="text-center"><%= l m.modified %></td>
     </tr>
   <% end %>

--- a/app/views/mailboxes/new.html.erb
+++ b/app/views/mailboxes/new.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">New mailbox</h4>
   <%= render 'form' %>
 </div>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -1,17 +1,17 @@
-<div class="card card-form">
+<div class="card">
   <h4 class="card-header">Change password</h4>
   <% if flash[:notice] %>
-    <div class="alert alert-primary" role="alert"><%= notice %></div>
+    <div class="alert-notice mx-4 mt-4 mb-0" role="alert"><%= notice %></div>
   <% end %>
 
   <%= form_for @current_admin, url: {controller: :profile, action: :update } do |f| %>
     <div class="card-body">
       <% if @current_admin.errors.any? %>
-        <div id="error_explanation">
-          <h2><%= pluralize(@current_admin.errors.count, "error") %> prohibited
+        <div id="error_explanation" class="alert-error">
+          <h2 class="font-semibold"><%= pluralize(@current_admin.errors.count, "error") %> prohibited
             this admin from being saved:</h2>
 
-          <ul>
+          <ul class="list-disc pl-5">
             <% @current_admin.errors.full_messages.each do |msg| %>
               <li><%= msg %></li>
             <% end %>
@@ -19,16 +19,14 @@
         </div>
       <% end %>
 
-      <div class="form-group">
-        <%= f.label :password_unencrypted %><br>
-        <%= f.password_field :password_unencrypted,
-                             size: 50, class: "form-control" %>
+      <div>
+        <%= f.label :password_unencrypted, class: "form-label" %>
+        <%= f.password_field :password_unencrypted, class: "form-input" %>
       </div>
 
-      <div class="form-group">
-        <%= f.label :password_unencrypted_confirmation %><br>
-        <%= f.password_field :password_unencrypted_confirmation,
-                             size: 50, class: "form-control" %>
+      <div>
+        <%= f.label :password_unencrypted_confirmation, class: "form-label" %>
+        <%= f.password_field :password_unencrypted_confirmation, class: "form-input" %>
       </div>
     </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,11 +1,11 @@
-<%= form_tag(nil, class: "form-signin", style: "max-width: 330px; margin: auto;") do %>
-  <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
+<%= form_tag(nil, class: "mx-auto max-w-xs text-left") do %>
+  <h1 class="mb-4 text-center text-xl text-gray-700">Please sign in</h1>
   <% if alert %>
-    <p id="notice"><%= alert %></p>
+    <p id="notice" class="alert-error"><%= alert %></p>
   <% end %>
-  <%= text_field_tag :username, nil, class: "form-control", placeholder: "Login (email)" %>
+  <%= text_field_tag :username, nil, class: "form-input mb-2", placeholder: "Login (email)" %>
 
-  <%= password_field_tag :password, nil, class: "form-control", placeholder: "Password" %>
+  <%= password_field_tag :password, nil, class: "form-input", placeholder: "Password" %>
 
-  <%= submit_tag 'Sign in', class: "btn btn-lg btn-primary btn-block", style: "margin-top: 20px" %>
+  <%= submit_tag 'Sign in', class: "btn btn-primary mt-5 w-full py-2 text-base" %>
 <% end %>

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,3 +3,4 @@
 pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "aliases", preload: true
+pin "dropdown", preload: true

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}


### PR DESCRIPTION
## Summary

Replace Bootstrap 4, jQuery and Sass with Tailwind CSS. The design was intentionally rebuilt as a simple admin look rather than replicating the Bootstrap appearance. This completes the frontend modernization: Sass, jQuery, Bootstrap and Node are all gone, which also clears the way for the Propshaft switch planned at Rails 8.0.

## Changes

- Gemfile: remove `bootstrap`, `jquery-rails`, `sassc-rails`; add `tailwindcss-rails` 2.5.0 (Tailwind v3, standalone binary - no Node)
- Define reusable component classes (`btn-*`, `card-*`, `table-admin`, form controls, alerts) in `application.tailwind.css` and rewrite all views (2 layouts + 14 templates)
- Replace the jQuery Bootstrap dropdown with a ~15 line vanilla JS module (`app/javascript/dropdown.js`) using a single delegated listener that keeps working across Turbo page visits
- Update `aliases.js` selectors for the new markup
- Delete `legacy.js` (jQuery/popper/bootstrap-sprockets) and the seven Sass files (the only real custom CSS was a card width)
- Remove `nodejs` from the Docker image (autoprefixer-rails is gone)
- Add `x86_64-linux` / `aarch64-linux` platforms to the lockfile for the tailwindcss native binaries
- CI: build Tailwind before running tests; README documents `bin/rails tailwindcss:build`

## Verification

- Unit/integration: 39 runs green; system: 6 runs green (dropdown, dynamic alias form, turbo_confirm dialog all covered by the system tests)
- Production assets:precompile outputs fingerprinted tailwind.css
- Browser check on login, domains index, mailboxes index (stats bar), alias edit form and the dropdown - screenshots reviewed

Generated with [Claude Code](https://claude.com/claude-code)