### PR TITLE
Rename DovecotCramMD5Password to DovecotCramMd5Password

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -2,7 +2,7 @@ class Admin < ApplicationRecord
   self.table_name = :admin
   self.primary_key = :username
 
-  include DovecotCramMD5Password
+  include DovecotCramMd5Password
 
   validates :username, presence: true, uniqueness: { case_sensitive: true },
                        format: { with: RE_EMAIL_LIKE_WITH_ANCHORS,

--- a/app/models/concerns/dovecot_cram_md5_password.rb
+++ b/app/models/concerns/dovecot_cram_md5_password.rb
@@ -1,6 +1,6 @@
 require 'active_support/concern'
 
-module DovecotCramMD5Password
+module DovecotCramMd5Password
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/mailbox.rb
+++ b/app/models/mailbox.rb
@@ -2,7 +2,7 @@ class Mailbox < ApplicationRecord
   self.table_name = :mailbox
   self.primary_key = :username
 
-  include DovecotCramMD5Password
+  include DovecotCramMd5Password
 
   attribute :quota_mb, :integer
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,9 +14,3 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
-
-# Zeitwerk expects DovecotCramMd5Password from the file name
-# dovecot_cram_md5_password, so register the actual module name
-Rails.autoloaders.each do |autoloader|
-  autoloader.inflector.inflect("dovecot_cram_md5_password" => "DovecotCramMD5Password")
-end

--- a/test/models/mailbox_test.rb
+++ b/test/models/mailbox_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class MailboxTest < ActiveSupport::TestCase
-  test "password round trip (DovecotCramMD5Password)" do
+  test "password round trip (DovecotCramMd5Password)" do
     mailbox = mailboxes(:user1)
     assert_equal mailbox, mailbox.authenticate("user1pass")
     assert_equal false, mailbox.authenticate("wrongpass")


### PR DESCRIPTION
## Summary

Rename the concern module to follow the Zeitwerk naming convention (`dovecot_cram_md5_password.rb` -> `DovecotCramMd5Password`) and remove the inflector registration in `config/initializers/inflections.rb` that worked around the mismatch since the Rails 6.0 upgrade.

## Verification

- No references to the old name remain (grep)
- `bin/rails zeitwerk:check` passes without the inflector registration
- Unit/integration 39 runs and system 6 runs green (including the password round-trip test)

Generated with [Claude Code](https://claude.com/claude-code)