### PR TITLE
Upgrade Ruby to 3.4.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Ref. https://docs.docker.com/compose/rails/
-FROM ruby:3.2.11
+FROM ruby:3.3.11
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Ref. https://docs.docker.com/compose/rails/
-FROM ruby:3.3.11
+FROM ruby:3.4.10
 
 WORKDIR /app
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,12 +155,12 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.17.2)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.17.2-aarch64-linux)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-linux)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     pp (0.6.4)
       prettyprint
@@ -296,7 +296,7 @@ DEPENDENCIES
   web-console (~> 4.0)
 
 RUBY VERSION
-   ruby 3.2.11p268
+   ruby 3.4.10p104
 
 BUNDLED WITH
    2.3.27


### PR DESCRIPTION
## Summary

Phase M of the upgrade plan, the final phase: Ruby 3.2.11 to 3.4.10 in two steps (3.3.11 then 3.4.10), one commit per step. Rails stays at 8.1.3.

This completes the whole upgrade milestone: the app now runs Rails 8.1.3 + Ruby 3.4.10 (security support until 2027-10 / 2028-03).

## Changes

- Update the Docker base image: `ruby:3.2.11` -> `ruby:3.3.11` -> `ruby:3.4.10`
- Update nokogiri from 1.17.2 to 1.19.4: the 1.17 precompiled binaries do not support Ruby 3.4, so without this the lockfile would drop the platform gems and fall back to building from source
- Refresh the `RUBY VERSION` record in Gemfile.lock with `bundle update --ruby` (now `ruby 3.4.10p104`)
- The Gemfile ruby requirement stays `>= 3.2.0` (the minimum supported by Rails 8.1)

## Verification

Full test suite was run at each step (3.3.11 and 3.4.10):

- `db:test:prepare` + `bin/rails test`: 39 runs, 113 assertions, 0 failures
- `bin/rails test:system`: 6 runs, 19 assertions, 0 failures
- `zeitwerk:check` and production `assets:precompile` (3.4.10): passed
- Manual browser check on 3.4.10: sign in/out, Turbo Drive navigation, dynamic alias form; no deprecation warnings in the server log