### PR TITLE
Migrate from byebug to the debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem 'bootsnap', '>= 1.16', require: false
 
 group :development, :test do
   gem 'pry-rails'
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # Call 'debugger' anywhere in the code to stop execution and get a debugger console
+  gem 'debug', platforms: [:mri, :windows], require: 'debug/prelude'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
     bootsnap (1.24.6)
       msgpack (~> 1.2)
     builder (3.3.0)
-    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -99,6 +98,9 @@ GEM
     connection_pool (2.5.5)
     crass (1.0.7)
     date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     dovecot_crammd5 (0.0.3)
     drb (2.2.3)
     erb (4.0.4.1)
@@ -279,8 +281,8 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.16)
-  byebug
   capybara
+  debug
   dovecot_crammd5
   importmap-rails (~> 1.2)
   listen (~> 3.3)


### PR DESCRIPTION
## Summary

Closes #42.

Replace byebug with the debug gem, the Rails default since Rails 7. byebug is unmaintained.

## Changes

- Replace `gem 'byebug'` with `gem 'debug', platforms: [:mri, :windows], require: 'debug/prelude'` in the development/test group, matching the Rails default Gemfile
- No breakpoint calls exist in the codebase, so nothing else changes

## Verification

- `debugger` and `binding.break` are defined from debug 1.11.1 (`debug/prelude`) inside the Docker container
- `bin/rails test`: 39 runs, 113 assertions, 0 failures
- `bin/rails test:system`: 6 runs, 19 assertions, 0 failures