### PR TITLE
Enable force_ssl in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
## Summary

Refs #41 (the force_ssl part; the Content Security Policy is still open).

Enable `config.force_ssl = true` in production as decided: all access is forced over SSL with Strict-Transport-Security and secure cookies.

`config.assume_ssl` stays commented out: Rails honors `X-Forwarded-Proto` by default, so TLS termination at a standard reverse proxy works without it. Enable it only if the proxy cannot pass that header.

## Verification

- Production environment boots with `force_ssl = true` (checked via `rails runner` with `RAILS_ENV=production`)
- `bin/rails test`: 39 runs, 113 assertions, 0 failures (test environment is unaffected)