### PR TITLE
Enable a Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,26 +4,27 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+# All assets are served from the app itself (Propshaft + importmap),
+# so every directive is restricted to :self with no external origins.
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.script_src  :self
+    policy.style_src   :self
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  # The importmap <script> tags and the Turbo progress bar <style> rely on these.
+  # On the very first request the session id is not generated yet, so fall
+  # back to a random per-request nonce to avoid blocking scripts with an
+  # empty nonce
+  config.content_security_policy_nonce_generator = ->(request) do
+    request.session.id.to_s.presence || SecureRandom.base64(16)
+  end
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
+end


### PR DESCRIPTION
## Summary

Closes #41 (force_ssl was already enabled by #44).

Enable an application-wide Content Security Policy. All assets are served by the app itself (Propshaft + importmap), so every directive is restricted to `'self'` with no external origins.

## Policy

- `default-src 'self'`, `font-src 'self'`, `img-src 'self' data:`, `object-src 'none'`
- `script-src 'self'` and `style-src 'self'` with session-based nonces (`content_security_policy_nonce_generator`), which the importmap `<script>` tags and the Turbo progress bar `<style>` rely on

## Note on the nonce generator

The Rails template uses `request.session.id.to_s`, but on the very first request the session id is not generated yet, so the nonce is empty and every script gets blocked (confirmed by inspecting the response header without a session cookie). The generator therefore falls back to a random per-request nonce in that case; subsequent requests use the stable session nonce, which keeps Turbo page caching consistent.

## Verification

- CSP header confirmed for both a fresh session (random nonce fallback) and an existing session (session nonce)
- Manual browser check: sign in (Turbo form submission), Turbo Drive navigation, Stimulus dynamic alias form, sign out; zero CSP violations in the console, Turbo and Stimulus load correctly
- `bin/rails test`: 39 runs, 113 assertions, 0 failures
- `bin/rails test:system`: 6 runs, 19 assertions, 0 failures (headless Chromium executes the app's JS with the policy enforced, so the system tests effectively exercise the CSP)