### PR TITLE
Move the database password to an environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,5 +13,5 @@
 
 - Development and tests run on Docker: `docker compose up -d db` -> `docker compose build app` -> `docker compose run --rm app bin/rails test`
 - The schema is managed with db/structure.sql (postfixadmin database version 1841), not with migrations
-- Initialize the development DB with `bin/rails db:create db:structure:load db:seed` (seeded login: admin@example.com / adminpass)
-- Note that `db:structure:load` loads into both development and test, so it fails with duplicate errors when the test DB is already loaded
+- Initialize the development DB with `bin/rails db:create db:schema:load db:seed` (seeded login: admin@example.com / adminpass)
+- `db:schema:load` only loads the development DB; the test DB is prepared separately with `bin/rails db:test:prepare`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Development and tests run on Docker:
 ```
 docker compose up -d db
 docker compose build app
-docker compose run --rm app bin/rails db:create db:structure:load db:seed
+docker compose run --rm app bin/rails db:create db:schema:load db:seed
 docker compose run --rm app bin/rails test
 docker compose up app   # http://localhost:3000 (admin@example.com / adminpass)
 ```

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,8 @@ default: &default
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: mailadmin
-  password: iBMVRf8bLP7vN49C5YmT
+  # Non-secret default for development and CI (see docker-compose.yml)
+  password: <%= ENV.fetch("MAILADMIN_DATABASE_PASSWORD", "mailadmin_dev") %>
   host: <%= ENV.fetch("DB_HOST", "127.0.0.1") %>
 
 development:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: rootpass
       MARIADB_USER: mailadmin
-      MARIADB_PASSWORD: iBMVRf8bLP7vN49C5YmT
+      # Non-secret default for development and CI; override with the
+      # environment variable for anything beyond local use
+      MARIADB_PASSWORD: ${MAILADMIN_DATABASE_PASSWORD:-mailadmin_dev}
       MARIADB_DATABASE: mailadmin_development
     ports:
       - "127.0.0.1:3306:3306"
@@ -25,6 +27,7 @@ services:
       - "3000:3000"
     environment:
       - DB_HOST=db
+      - MAILADMIN_DATABASE_PASSWORD
     volumes:
       - .:/app
 


### PR DESCRIPTION
## Summary

Closes #40.

Replace the hardcoded database password with the `MAILADMIN_DATABASE_PASSWORD` environment variable, using a non-secret default (`mailadmin_dev`) for development and CI.

## Changes

- `config/database.yml`: the default block reads `ENV.fetch("MAILADMIN_DATABASE_PASSWORD", "mailadmin_dev")`; the production block keeps requiring the variable with no fallback
- `docker-compose.yml`: `MARIADB_PASSWORD: ${MAILADMIN_DATABASE_PASSWORD:-mailadmin_dev}` and the variable is passed through to the app container
- Rotation: the dev DB volume was recreated with the new default; no copy of the old password remains anywhere in the repository (verified by grep)
- CI needs no changes: the same default applies there, and fork PRs keep working since no secret is involved
- Docs: `db:structure:load` was removed in Rails 8.1, so README/CLAUDE.md now use `db:create db:schema:load db:seed`; unlike the old task, `db:schema:load` does not touch the test DB (verified), which `db:test:prepare` handles

## Verification

- Fresh DB initialization with the new default: `db:create db:schema:load db:seed` succeeded, seeded login works
- `db:test:prepare` + `bin/rails test`: 39 runs, 113 assertions, 0 failures
- `bin/rails test:system`: 6 runs, 19 assertions, 0 failures